### PR TITLE
Removing unnecessary regex use.

### DIFF
--- a/src/main/java/net/simplyvanilla/simplychat/command/MessageCommandExecutor.java
+++ b/src/main/java/net/simplyvanilla/simplychat/command/MessageCommandExecutor.java
@@ -33,7 +33,7 @@ public class MessageCommandExecutor implements CommandExecutor {
 
         if (receiver == null) {
             String message = plugin.getColorCodeTranslatedConfigString("command.message.receiverNotFoundMessage");
-            message = message.replaceAll("\\[receiver]", Matcher.quoteReplacement(args[0]));
+            message = message.replace("[receiver]", Matcher.quoteReplacement(args[0]));
             sender.sendMessage(message);
             return true;
         }

--- a/src/main/java/net/simplyvanilla/simplychat/command/MessageCommandExecutor.java
+++ b/src/main/java/net/simplyvanilla/simplychat/command/MessageCommandExecutor.java
@@ -33,7 +33,7 @@ public class MessageCommandExecutor implements CommandExecutor {
 
         if (receiver == null) {
             String message = plugin.getColorCodeTranslatedConfigString("command.message.receiverNotFoundMessage");
-            message = message.replace("[receiver]", Matcher.quoteReplacement(args[0]));
+            message = message.replace("[receiver]", args[0]);
             sender.sendMessage(message);
             return true;
         }

--- a/src/main/java/net/simplyvanilla/simplychat/command/MessageFormat.java
+++ b/src/main/java/net/simplyvanilla/simplychat/command/MessageFormat.java
@@ -7,9 +7,9 @@ public final class MessageFormat {
     private MessageFormat() {}
 
     public static String expandInternalPlaceholders(String senderName, String receiverName, String message, String format) {
-        return format.replaceAll("\\[sender]", senderName)
-                .replaceAll("\\[receiver]", receiverName)
-                .replaceAll("\\[message]", Matcher.quoteReplacement(message));
+        return format.replace("[sender]", senderName)
+                .replace("[receiver]", receiverName)
+                .replace("[message]", message);
     }
 
 }


### PR DESCRIPTION
Regex usage is unnecessary in this scenario. Using regex is harder to maintain and more error prone.

The following has been used for testing:
`/msg [NAME] Test`  --Result--> `You -> [NAME] >> Test`
`/msg [NAME] Test\`  --Result--> `You -> [NAME] >> Test\`